### PR TITLE
ResolvedType.getAllTypes() returns parent, this, and interfaces

### DIFF
--- a/src/main/java/com/fasterxml/classmate/ResolvedType.java
+++ b/src/main/java/com/fasterxml/classmate/ResolvedType.java
@@ -97,6 +97,26 @@ public abstract class ResolvedType
     public abstract List<ResolvedType> getImplementedInterfaces();
 
     /**
+     * Returns Ordered list of parent, current and interfaces of this type.
+     *
+     * @return List of parent, current and interfaces of this type containing at least current type
+     */
+    public List<ResolvedType> getAllTypes() {
+        List<ResolvedType> allTypes = new ArrayList<ResolvedType>();
+        ResolvedType parentClass = getParentClass();
+        if (parentClass != null) {
+            allTypes.add(parentClass);
+        }
+        allTypes.add(this);
+        List<ResolvedType> implementedInterfaces = getImplementedInterfaces();
+        if (implementedInterfaces != null) {
+            allTypes.addAll(implementedInterfaces);
+        }
+
+        return allTypes;
+    };
+
+    /**
      * Returns list of generic type declarations for this type, in order they
      * are declared in class description.
      */

--- a/src/test/java/com/fasterxml/classmate/ResolvedTypeTest.java
+++ b/src/test/java/com/fasterxml/classmate/ResolvedTypeTest.java
@@ -19,7 +19,13 @@ public class ResolvedTypeTest extends BaseTest
     private static class Bar16 extends Zen16<Bar16, Foo16> { }
 
     private static class Zen16<A, B extends A>  { }
-    
+
+    private static class ClassWithInterfaces implements FirstInterface, SecondInterface { }
+
+    interface FirstInterface {}
+
+    interface SecondInterface {}
+
     @Test
     public void testCanCreateSubtype() {
         ResolvedObjectType stringType = ResolvedObjectType.create(String.class, null, null, null);
@@ -139,5 +145,20 @@ public class ResolvedTypeTest extends BaseTest
 
         assertEquals(Bar16.class, params.get(0).getErasedType());
         assertEquals(Foo16.class, params.get(1).getErasedType());
+    }
+
+    @Test
+    public void testFindAllClasses() {
+        TypeResolver resolver = new TypeResolver();
+        ResolvedType type = resolver.resolve(ClassWithInterfaces.class);
+
+        List<ResolvedType> allTypes = type.getAllTypes();
+
+        assertNotNull(allTypes);
+        assertEquals(4, allTypes.size());
+        assertEquals(Object.class, allTypes.get(0).getErasedType());
+        assertEquals(ClassWithInterfaces.class, allTypes.get(1).getErasedType());
+        assertEquals(FirstInterface.class, allTypes.get(2).getErasedType());
+        assertEquals(SecondInterface.class, allTypes.get(3).getErasedType());
     }
 }


### PR DESCRIPTION
Convenience method for the full set of types for a type (fixes #50)