### PR TITLE
Fix flaky tests in GhostTypeParameterInFieldTest

### DIFF
--- a/src/test/java/com/fasterxml/classmate/members/GhostTypeParameterInFieldTest.java
+++ b/src/test/java/com/fasterxml/classmate/members/GhostTypeParameterInFieldTest.java
@@ -1,5 +1,7 @@
 package com.fasterxml.classmate.members;
 
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 
 import junit.framework.TestCase;
@@ -29,12 +31,18 @@ public class GhostTypeParameterInFieldTest
         MemberResolver memberResolver = new MemberResolver(resolver);
         ResolvedTypeWithMembers resolvedTypeWithMembers = memberResolver.resolve(resolvedType, null, null);
         ResolvedField[] fields = resolvedTypeWithMembers.getMemberFields();
+        Arrays.sort(fields, new Comparator<ResolvedField>(){
+            @Override
+            public int compare(ResolvedField f1, ResolvedField f2) {
+                return (f1.toString()).compareTo(f2.toString());
+            }
+        });
 
         // test fields
         assertEquals(3, fields.length);
 
         // field List<T> listOfT
-        ResolvedField listOfT_Field = fields[0];
+        ResolvedField listOfT_Field = fields[1];
         assertEquals("listOfT", listOfT_Field.getName());
         ResolvedType listOfT_Type = listOfT_Field.getType();
         assertEquals(List.class, listOfT_Type.getErasedType());
@@ -43,7 +51,7 @@ public class GhostTypeParameterInFieldTest
         assertEquals(Integer.class, listOfT_TypeParams.get(0).getErasedType());
 
         // field t
-        ResolvedField t_Field = fields[1];
+        ResolvedField t_Field = fields[2];
         assertEquals("t", t_Field.getName());
         ResolvedType t_Type = t_Field.getType();
         assertEquals(Integer.class, t_Type.getErasedType());
@@ -51,7 +59,7 @@ public class GhostTypeParameterInFieldTest
         assertEquals("Expected 0 type parameter for t, got " + t_TypeParams.size() + ": " + t_TypeParams, 0, t_TypeParams.size());
 
         // field i
-        ResolvedField i_Field = fields[2];
+        ResolvedField i_Field = fields[0];
         assertEquals("i", i_Field.getName());
         ResolvedType i_Type = i_Field.getType();
         assertEquals(Integer.class, i_Type.getErasedType());
@@ -66,12 +74,18 @@ public class GhostTypeParameterInFieldTest
         MemberResolver memberResolver = new MemberResolver(resolver);
         ResolvedTypeWithMembers resolvedTypeWithMembers = memberResolver.resolve(resolvedType, null, null);
         ResolvedField[] fields = resolvedTypeWithMembers.getMemberFields();
+        Arrays.sort(fields, new Comparator<ResolvedField>(){
+            @Override
+            public int compare(ResolvedField f1, ResolvedField f2) {
+                return (f1.toString()).compareTo(f2.toString());
+            }
+        });
 
         // test fields
         assertEquals(3, fields.length);
 
         // field List<T> listOfT
-        ResolvedField listOfT_Field = fields[0];
+        ResolvedField listOfT_Field = fields[1];
         assertEquals("listOfT", listOfT_Field.getName());
         ResolvedType listOfT_Type = listOfT_Field.getType();
         assertEquals(List.class, listOfT_Type.getErasedType());
@@ -80,7 +94,7 @@ public class GhostTypeParameterInFieldTest
         assertEquals(Integer.class, listOfT_TypeParams.get(0).getErasedType());
 
         // field t
-        ResolvedField t_Field = fields[1];
+        ResolvedField t_Field = fields[2];
         assertEquals("t", t_Field.getName());
         ResolvedType t_Type = t_Field.getType();
         assertEquals(Integer.class, t_Type.getErasedType());
@@ -88,7 +102,7 @@ public class GhostTypeParameterInFieldTest
         assertEquals("Expected 0 type parameter for t, got " + t_TypeParams.size() + ": " + t_TypeParams, 0, t_TypeParams.size());
 
         // field i
-        ResolvedField i_Field = fields[2];
+        ResolvedField i_Field = fields[0];
         assertEquals("i", i_Field.getName());
         ResolvedType i_Type = i_Field.getType();
         assertEquals(Number.class, i_Type.getErasedType());


### PR DESCRIPTION
The tests `testGhostTypeParameterWithClass()` and `testGhostTypeParameterWithInterface()` are flaky because `getMemberFields()` will return fields in nondeterministic order. I sort the array so the order of fields in the array will always be the same. 