### PR TITLE
Simplify code by not calling `Set.contains()` before `add()`

### DIFF
--- a/VERSION.txt
+++ b/VERSION.txt
@@ -6,6 +6,8 @@ Release notes:
 1.7.0 (not yet released)
 
 #75: Move JDK baseline to Java 8
+ (contributed by Dave B, @mebigfatguy)
+#83: Simplify code by not calling `Set.contains()` before `add()`
 - Remove `Automatic-Module-Name` since we provide proper module-info
 
 1.6.0 (10-Oct-2023)

--- a/src/main/java/com/fasterxml/classmate/MemberResolver.java
+++ b/src/main/java/com/fasterxml/classmate/MemberResolver.java
@@ -175,8 +175,7 @@ public class MemberResolver implements Serializable
     private void _addOverrides(List<HierarchicType> typesWithOverrides, Set<ClassKey> seenTypes, Class<?> override)
     {
         ClassKey key = new ClassKey(override);
-        if (!seenTypes.contains(key)) {
-            seenTypes.add(key);
+        if (seenTypes.add(key)) {
             ResolvedType resolvedOverride = _typeResolver.resolve(override);
             typesWithOverrides.add(new HierarchicType(resolvedOverride, true, typesWithOverrides.size()));
             for (ResolvedType r : resolvedOverride.getImplementedInterfaces()) { // interfaces?
@@ -194,8 +193,7 @@ public class MemberResolver implements Serializable
         Class<?> raw = override.getErasedType();
         if (!_cfgIncludeLangObject && Object.class == raw) return;
         ClassKey key = new ClassKey(raw);
-        if (!seenTypes.contains(key)) {
-            seenTypes.add(key);
+        if (seenTypes.add(key)) {
             typesWithOverrides.add(new HierarchicType(override, true, typesWithOverrides.size()));
             for (ResolvedType r : override.getImplementedInterfaces()) { // interfaces?
                 _addOverrides(typesWithOverrides, seenTypes, r);
@@ -227,11 +225,10 @@ public class MemberResolver implements Serializable
         }
         // Finally, only include first instance of an interface, so:
         ClassKey key = new ClassKey(currentType.getErasedType());
-        if (seenTypes.contains(key)) {
+        if (!seenTypes.add(key)) {
             return;
         }
         // If all good so far, append
-        seenTypes.add(key);
         types.add(currentType);
         /* and check supertypes; starting with interfaces. Why interfaces?
          * So that "highest" interfaces get priority; otherwise we'd recurse


### PR DESCRIPTION
No need to do contains before add, just does two set traversals instead of one.